### PR TITLE
Add pytest configuration to include package on path

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- ensure pytest runs without setting PYTHONPATH by adding pytest.ini

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae7273d28832e8fee70e642f15a8d